### PR TITLE
Fix algorithm page navigation links

### DIFF
--- a/projects/algolt/algorithms/bfs.html
+++ b/projects/algolt/algorithms/bfs.html
@@ -207,8 +207,8 @@ return result;
 </section>
 
 <section class="card p-6 text-center">
-  <a href="./depth-first-search.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
-    Next: Depth First Search 
+  <a href="./bubble-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
+    Next: Bubble Sort
     <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
     </svg>

--- a/projects/algolt/algorithms/binary-search.html
+++ b/projects/algolt/algorithms/binary-search.html
@@ -233,7 +233,16 @@ function binarySearch(arr, target) {
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
         </svg>
       </a>
-    </section>
+  </section>
+
+  <section class="card p-6 text-center">
+    <a href="./dfs.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
+      Next: Depth First Search
+      <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+      </svg>
+    </a>
+  </section>
   </main>
 
   <!-- Include the external quiz system -->

--- a/projects/algolt/algorithms/bubble-sort.html
+++ b/projects/algolt/algorithms/bubble-sort.html
@@ -171,8 +171,8 @@ function bubbleSort(arr) {
     </section>
 
     <section class="card p-6 text-center">
-      <a href="./insertion-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
-        Next: Insertion Sort 
+      <a href="./quick-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
+        Next: Quick Sort
         <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
         </svg>

--- a/projects/algolt/algorithms/bucket-sort.html
+++ b/projects/algolt/algorithms/bucket-sort.html
@@ -191,8 +191,8 @@ function bucketSort(arr) {
     </section>
 
     <section class="card p-6 text-center">
-      <a href="./radix-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
-        Next: Radix Sort 
+      <a href="./counting-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
+        Next: Counting Sort
         <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
         </svg>

--- a/projects/algolt/algorithms/counting-sort.html
+++ b/projects/algolt/algorithms/counting-sort.html
@@ -187,8 +187,8 @@ function countingSort(arr) {
     </section>
 
     <section class="card p-6 text-center">
-      <a href="./radix-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
-        Next: Radix Sort 
+      <a href="./binary-search.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
+        Next: Binary Search
         <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
         </svg>

--- a/projects/algolt/algorithms/heap-sort.html
+++ b/projects/algolt/algorithms/heap-sort.html
@@ -187,8 +187,8 @@ function heapify(arr, n, i) {
     </section>
 
     <section class="card p-6 text-center">
-      <a href="./quick-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
-        Next: Quick Sort 
+      <a href="./radix-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
+        Next: Radix Sort
         <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
         </svg>

--- a/projects/algolt/algorithms/merge-sort.html
+++ b/projects/algolt/algorithms/merge-sort.html
@@ -180,8 +180,8 @@ function merge(left, right) {
     </section>
 
     <section class="card p-6 text-center">
-      <a href="./quick-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
-        Next: Quick Sort 
+      <a href="./insertion-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
+        Next: Insertion Sort
         <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
         </svg>

--- a/projects/algolt/algorithms/radix-sort.html
+++ b/projects/algolt/algorithms/radix-sort.html
@@ -242,8 +242,8 @@ function getDigit(num, place) {
     </section>
 
     <section class="card p-6 text-center">
-      <a href="./merge-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
-        Next: Merge Sort 
+      <a href="./bucket-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
+        Next: Bucket Sort
         <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
         </svg>

--- a/projects/algolt/algorithms/selection-sort.html
+++ b/projects/algolt/algorithms/selection-sort.html
@@ -172,8 +172,8 @@ function selectionSort(arr) {
     </section>
 
     <section class="card p-6 text-center">
-      <a href="./merge-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
-        Next: Merge Sort 
+      <a href="./heap-sort.html" class="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors">
+        Next: Heap Sort
         <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
         </svg>


### PR DESCRIPTION
## Summary
- update navigation links between algorithm pages so the order matches the main index
- add missing link on `binary-search.html`
- correct BFS page link

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6851b2e729d08333bd5a6283eef9a6c3